### PR TITLE
Fixed production of incorrect paths

### DIFF
--- a/src/polyline.js
+++ b/src/polyline.js
@@ -106,8 +106,8 @@ polyline.encodeLine = function(coordinates) {
 
         output += this.encodePoint(pt[0], pt[1]);
 
-        latitude = pt[0];
-        longitude = pt[1];
+        latitude = coordinates[i][0];
+        longitude = coordinates[i][1];
     }
     return output;
 };


### PR DESCRIPTION
The previous implementation of the polyline algorithm produced incorrect paths due to using the wrong lat/lon as the base for the next loop cycle. This led to paths generated that when decoded did not match the data encoded (even within the 5 decimal place precision of the algorithm) after the second point.
