### PR TITLE
Add flip function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/API.md
+++ b/API.md
@@ -9,7 +9,6 @@ precision defaults to 5.
 Takes an array of lat, lon arrays and returns an encoded
 string. If not specified, precision defaults to 5.
 
-### polyline.flip(geojson)
+### polyline.fromGeoJSON(geojson[, precision])
 
-Takes a GeoJSON FeatureCollection, Feature, or Geometry
-and returns its coordinates as a lat/lon array.
+Takes a GeoJSON LineString feature and returns an encoded string. If not specified, precision defaults to 5.

--- a/API.md
+++ b/API.md
@@ -8,3 +8,8 @@ precision defaults to 5.
 
 Takes an array of lat, lon arrays and returns an encoded
 string. If not specified, precision defaults to 5.
+
+### polyline.flip(geojson)
+
+Takes a GeoJSON FeatureCollection, Feature, or Geometry
+and returns its coordinates as a lat/lon array.

--- a/README.md
+++ b/README.md
@@ -16,21 +16,20 @@ Encodes/decodes into lat/lng coordinate pairs. Use `fromGeoJSON()` to encode fro
 ```js
 var polyline = require('polyline');
 
-// returns an array of lat, lon pairs you can pass to polyline.encode()
-polyline.flip({ 
-  "type": "Feature",
-    "properties": {},
-    "geometry": {
-      "type": "Point",
-      "coordinates": [20.566406, 43.421008]
-    }
-  });
-
 // returns an array of lat, lon pairs
 polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
 
 // returns a string-encoded polyline
 polyline.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]);
+
+// returns a string-encoded polyline from a GeoJSON LineString
+polyline.fromGeoJSON({ "type": "Feature",
+  "geometry": {
+    "type": "LineString",
+    "coordinates": example_flipped
+  },
+  "properties": {}
+});
 ```
 
 # [Documentation](https://github.com/mapbox/polyline/blob/master/API.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A simple [google-esque polyline](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
 implementation in Javascript. Compatible with nodejs (`npm install polyline` and the browser (copy `src/polyline.js`)).
 
-Encodes/decodes into lat/lng coordinate pairs. Flip the pairs to be compatible with GeoJSON.
+Encodes/decodes into lat/lng coordinate pairs. Use `fromGeoJSON()` to encode from GeoJSON objects.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,18 @@ Encodes/decodes into lat/lng coordinate pairs. Flip the pairs to be compatible w
 ```js
 var polyline = require('polyline');
 
+// returns an array of lat, lon pairs you can pass to polyline.encode()
+polyline.flip({ 
+  "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "Point",
+      "coordinates": [20.566406, 43.421008]
+    }
+  });
+
 // returns an array of lat, lon pairs
-polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@')
+polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
 
 // returns a string-encoded polyline
 polyline.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]);

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "type": "git",
     "url": "git://github.com/mapbox/polyline.git"
   },
-  "dependencies": { 
-    "turf-flip": "*",
-    "geojson-coords": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jshint": "2.3.0",
     "mocha": "1.2.x"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "git://github.com/mapbox/polyline.git"
   },
-  "dependencies": {},
+  "dependencies": { 
+    "turf-flip": "*",
+    "geojson-coords": "*"
+  },
   "devDependencies": {
     "jshint": "2.3.0",
     "mocha": "1.2.x"

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -86,12 +86,16 @@ polyline.encode = function(coordinates, precision) {
     return output;
 };
 
-polyline.flip = function(input) {
-    
-    var flipped = turfFlip(input);
-
-    return getCoords(flipped);
-
+polyline.fromGeoJSON = function(geojson, precision) {
+    if (!(geojson && geojson.geometry && geojson.geometry.type === 'LineString')) {
+        throw new Error('Input must be a GeoJSON LineString');
+    }
+    var coords = geojson.geometry.coordinates;
+    var flipped = [];
+    for (var i = 0; i < coords.length; i++) {
+        flipped.push(coords[i].slice().reverse());
+    }
+    return polyline.encode(flipped, precision);
 };
 
 if (typeof module === 'object' && module.exports) module.exports = polyline;

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -1,3 +1,6 @@
+var turfFlip = require('turf-flip');
+var geojsonCoords = require('geojson-coords');
+
 var polyline = {};
 
 // Based off of [the offical Google document](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
@@ -18,6 +21,10 @@ function encode(coordinate, factor) {
     }
     output += String.fromCharCode(coordinate + 63);
     return output;
+}
+
+function getCoords(geojson) {
+    return geojsonCoords(geojson);
 }
 
 // This is adapted from the implementation in Project-OSRM
@@ -84,6 +91,14 @@ polyline.encode = function(coordinates, precision) {
     }
 
     return output;
+};
+
+polyline.flip = function(input) {
+    
+    var flipped = turfFlip(input);
+
+    return getCoords(flipped);
+
 };
 
 if (typeof module === 'object' && module.exports) module.exports = polyline;

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -87,10 +87,15 @@ polyline.encode = function(coordinates, precision) {
 };
 
 polyline.fromGeoJSON = function(geojson, precision) {
-    if (!(geojson && geojson.geometry && geojson.geometry.type === 'LineString')) {
+    if (!(geojson && geojson.geometry && geojson.geometry.type === 'LineString') && geojson.type != 'LineString') {
         throw new Error('Input must be a GeoJSON LineString');
     }
-    var coords = geojson.geometry.coordinates;
+    var coords;
+    if (geojson.geometry) {
+        coords = geojson.geometry.coordinates;
+    } else {
+        coords = geojson.coordinates;
+    }
     var flipped = [];
     for (var i = 0; i < coords.length; i++) {
         flipped.push(coords[i].slice().reverse());

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -87,15 +87,13 @@ polyline.encode = function(coordinates, precision) {
 };
 
 polyline.fromGeoJSON = function(geojson, precision) {
-    if (!(geojson && geojson.geometry && geojson.geometry.type === 'LineString') && geojson.type != 'LineString') {
+    if (geojson && geojson.type === 'Feature') {
+        geojson = geojson.geometry;
+    }
+    if (!geojson || geojson.type !== 'LineString') {
         throw new Error('Input must be a GeoJSON LineString');
     }
-    var coords;
-    if (geojson.geometry) {
-        coords = geojson.geometry.coordinates;
-    } else {
-        coords = geojson.coordinates;
-    }
+    var coords = geojson.coordinates;
     var flipped = [];
     for (var i = 0; i < coords.length; i++) {
         flipped.push(coords[i].slice().reverse());

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -1,6 +1,3 @@
-var turfFlip = require('turf-flip');
-var geojsonCoords = require('geojson-coords');
-
 var polyline = {};
 
 // Based off of [the offical Google document](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
@@ -21,10 +18,6 @@ function encode(coordinate, factor) {
     }
     output += String.fromCharCode(coordinate + 63);
     return output;
-}
-
-function getCoords(geojson) {
-    return geojsonCoords(geojson);
 }
 
 // This is adapted from the implementation in Project-OSRM

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -1,32 +1,18 @@
 var assert = require('assert'),
-    polyline = require('../'),
-    package = require('../package.json');
+    polyline = require('../');
 
 describe('polyline', function() {
     var example = [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
         // encoded value will enclude slashes -> tests escaping
         example_slashes = [[35.6,-82.55], [35.59985, -82.55015], [35.6,-82.55]],
-        example_flipped = [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]],
-        dependencies = { "turf-flip": "*", "geojson-coords": "*" }
-        geojson = {
-            "type": "Feature",
-            "properties": {},
+        example_flipped = [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]];
+        geojson = { "type": "Feature",
             "geometry": {
-                "type": "Point",
-                "coordinates": [20.566406, 43.421008]
-            }
-        },
-        flipped_coords = [43.421008, 20.566406];
-
-    describe('#dependencies', function() {
-        it('loads turf-flip as a dependency', function() {
-            assert(package.dependencies['turf-flip']);
-        });
-
-        it ('loads geojson-coords as a dependency', function() {
-            assert(package.dependencies['geojson-coords']);
-        })
-    });
+                "type": "LineString",
+                "coordinates": example_flipped
+            },
+            "properties": {}
+        }
 
     describe('#decode()', function() {
         it('decodes an empty Array', function() {
@@ -66,13 +52,16 @@ describe('polyline', function() {
         });
     });
 
-    describe('#flip()', function() {
-        it('returns coordinates from geojson', function() {
-            assert.equal(typeof(polyline.flip(geojson)), 'object');
+    describe('#fromGeoJSON()', function() {
+        it('throws for non linestrings', function() {
+            assert.throws(function() {
+                polyline.fromGeoJSON({});
+            }, /Input must be a GeoJSON LineString/);
         });
 
-        it ('flips geometry', function() {
-            assert.deepEqual(polyline.flip(geojson), [flipped_coords]);
-        })
+        it('flips coordinates and encodes', function() {
+            assert.equal(polyline.fromGeoJSON(geojson), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+        });
     });
+
 });

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -58,6 +58,11 @@ describe('polyline', function() {
                 polyline.fromGeoJSON({});
             }, /Input must be a GeoJSON LineString/);
         });
+        console.log(geojson.geometry);
+
+        it('allows geojson geometries', function() {
+            assert.equal(polyline.fromGeoJSON(geojson.geometry), '_p~iF~ps|U_ulLnnqC_mqNvxq`@')
+        })
 
         it('flips coordinates and encodes', function() {
             assert.equal(polyline.fromGeoJSON(geojson), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -58,7 +58,6 @@ describe('polyline', function() {
                 polyline.fromGeoJSON({});
             }, /Input must be a GeoJSON LineString/);
         });
-        console.log(geojson.geometry);
 
         it('allows geojson geometries', function() {
             assert.equal(polyline.fromGeoJSON(geojson.geometry), '_p~iF~ps|U_ulLnnqC_mqNvxq`@')

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -1,10 +1,32 @@
 var assert = require('assert'),
-    polyline = require('../');
+    polyline = require('../'),
+    package = require('../package.json');
 
 describe('polyline', function() {
     var example = [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
         // encoded value will enclude slashes -> tests escaping
-        example_slashes = [[35.6,-82.55], [35.59985, -82.55015], [35.6,-82.55]];
+        example_slashes = [[35.6,-82.55], [35.59985, -82.55015], [35.6,-82.55]],
+        example_flipped = [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]],
+        dependencies = { "turf-flip": "*", "geojson-coords": "*" }
+        geojson = {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Point",
+                "coordinates": [20.566406, 43.421008]
+            }
+        },
+        flipped_coords = [43.421008, 20.566406];
+
+    describe('#dependencies', function() {
+        it('loads turf-flip as a dependency', function() {
+            assert(package.dependencies['turf-flip']);
+        });
+
+        it ('loads geojson-coords as a dependency', function() {
+            assert(package.dependencies['geojson-coords']);
+        })
+    });
 
     describe('#decode()', function() {
         it('decodes an empty Array', function() {
@@ -42,5 +64,15 @@ describe('polyline', function() {
         it('encodes with a custom precision', function() {
             assert.equal(polyline.encode(example, 6), '_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI');
         });
+    });
+
+    describe('#flip()', function() {
+        it('returns coordinates from geojson', function() {
+            assert.equal(typeof(polyline.flip(geojson)), 'object');
+        });
+
+        it ('flips geometry', function() {
+            assert.deepEqual(polyline.flip(geojson), [flipped_coords]);
+        })
     });
 });


### PR DESCRIPTION
This PR:

- adds a "flip" function that takes geojson and returns an array of lat/lon coordinate pairs suitable for passing into `polyline.encode()`
- adds tests for new function and dependencies
- adds documentation and README changes reflecting the new function

This is my first time writing tests or adding to a node module, so please let me know if I need to change anything! /cc @tmcw 