### PR TITLE
Fix negative value handling

### DIFF
--- a/src/polyline.js
+++ b/src/polyline.js
@@ -11,10 +11,10 @@
 
 var polyline = {};
 
-function encode(coordinate, factor) {
-    coordinate = Math.round(coordinate * factor);
+function encode(coord, factor) {
+    var coordinate = Math.round(coord * factor);
     coordinate <<= 1;
-    if (coordinate < 0) {
+    if (coord < 0) {
         coordinate = ~coordinate;
     }
     var output = '';

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -66,6 +66,12 @@ test('polyline', function(t) {
             t.end();
         });
 
+        t.test('encodes negative values correctly', function(t) {
+            t.ok(polyline.decode(polyline.encode([[-107.3741825, 0]], 7), 7)[0][0] < 0);
+            t.end();
+        });
+
+
         t.end();
     });
 


### PR DESCRIPTION
According to Google's documentation, value should be inverted if
_original_ value is less than zero. In practice it seems to affect results
only if precision is 7 or greater.