### PR TITLE
Polyfill for Math.sign

### DIFF
--- a/src/polyline.js
+++ b/src/polyline.js
@@ -11,6 +11,23 @@
 
 var polyline = {};
 
+// Math.sign is unsupported in IE.
+// Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
+if (!Math.sign) {
+  Math.sign = function(x) {
+    // If x is NaN, the result is NaN.
+    // If x is -0, the result is -0.
+    // If x is +0, the result is +0.
+    // If x is negative and not -0, the result is -1.
+    // If x is positive and not +0, the result is +1.
+    x = +x; // convert to a number
+    if (x === 0 || isNaN(x)) {
+      return Number(x);
+    }
+    return x > 0 ? 1 : -1;
+  };
+}
+
 function py2_round(value) {
     // Google's polyline algorithm uses the same rounding strategy as Python 2, which is different from JS for negative values
     return Math.floor(Math.abs(value) + 0.5) * Math.sign(value);


### PR DESCRIPTION
Math.sign is unsupported in IE.