### PR TITLE
Point and Polygon GeoJSON geometry types support

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,8 +11,8 @@ string. If not specified, precision defaults to 5.
 
 ### polyline.fromGeoJSON(geojson[, precision])
 
-Takes a GeoJSON LineString feature and returns an encoded string. If not specified, precision defaults to 5.
+Takes a GeoJSON Point, LineString, or Polygon feature and returns an encoded string. If not specified, precision defaults to 5.
 
 ### polyline.toGeoJSON(string[, precision])
 
-Takes an encoded string and returns a GeoJSON LineString geometry. If not specified, precision defaults to 5.
+Takes an encoded string and returns a GeoJSON Point or LineString geometry. If not specified, precision defaults to 5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (2018-12-26)
+
+* Added `Point` and `Polygon` GeoJSON geometry types support.
+
 ## 1.0.0 (2018-04-01)
 
 * Added `--toGeoJSON` command line option.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A simple [google-esque polyline](https://developers.google.com/maps/documentatio
 implementation in Javascript. Compatible with nodejs (`npm install @mapbox/polyline` and the browser (copy `src/polyline.js`)).
 
 Encodes/decodes into [lat, lng] coordinate pairs. Use `fromGeoJSON()` to encode from GeoJSON objects, or `toGeoJSON` to
-decode to a GeoJSON LineString.
+decode to a GeoJSON Point, LineString, or Polygon (holes not supported).
 
 ## Installation
 
     npm install @mapbox/polyline
-    
+
 Note that the old package `polyline` has been deprecated in favor of `@mapbox/polyline` (the old package remain but won't receive updates).
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Tom MacWright <tom@macwright.org> (http://macwright.org/)",
   "name": "@mapbox/polyline",
   "description": "Polyline encoding and decoding",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/polyline.git"

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -11,13 +11,21 @@ test('polyline', function(t) {
         example_rounding = [[0, 0.000006], [0, 0.000002]],
         example_rounding_negative = [[36.05322, -112.084004], [36.053573, -112.083914], [36.053845, -112.083965]];
 
-    var geojson = { 'type': 'Feature',
-        'geometry': {
-            'type': 'LineString',
-            'coordinates': example_flipped
+    var geojsonLineString = { 'type': 'Feature',
+            'geometry': {
+                'type': 'LineString',
+                'coordinates': example_flipped
+            },
+            'properties': {}
         },
-        'properties': {}
-    };
+        geojsonPoint = {
+            'type': 'Point',
+            'coordinates': example_flipped[0]
+        },
+        geojsonPolygon = {
+            'type': 'Polygon',
+            'coordinates': [[[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252], [-120.2, 38.5]]]
+        };
 
     t.test('#decode()', function(t) {
         t.test('decodes an empty Array', function(t) {
@@ -88,20 +96,37 @@ test('polyline', function(t) {
     });
 
     t.test('#fromGeoJSON()', function(t) {
-        t.test('throws for non linestrings', function(t) {
+        t.test('throws for empty geojson', function(t) {
             t.throws(function() {
-                polyline.fromGeoJSON({});
-            }, /Input must be a GeoJSON LineString/);
+                polyline.fromGeoJSON();
+            }, /Input must be a valid GeoJSON/);
             t.end();
         });
 
-        t.test('allows geojson geometries', function(t) {
-            t.equal(polyline.fromGeoJSON(geojson.geometry), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+        t.test('throws for unsupported geometry type', function(t) {
+            t.throws(function() {
+                polyline.fromGeoJSON({ type: 'MultiPolygon' });
+            }, /Input must be a GeoJSON Point, LineString or Polygon/);
             t.end();
         });
 
-        t.test('flips coordinates and encodes', function(t) {
-            t.equal(polyline.fromGeoJSON(geojson), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+        t.test('allows geojson linestring', function(t) {
+            t.equal(polyline.fromGeoJSON(geojsonLineString.geometry), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.test('flips linestring coordinates and encodes', function(t) {
+            t.equal(polyline.fromGeoJSON(geojsonLineString), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.test('flips point coordinate end encodes', function(t) {
+            t.equal(polyline.fromGeoJSON(geojsonPoint), '_p~iF~ps|U');
+            t.end();
+        });
+
+        t.test('flips polygon coordinates end encodes', function(t) {
+            t.equal(polyline.fromGeoJSON(geojsonPolygon), '_p~iF~ps|U_ulLnnqC_mqNvxq`@~b_\\ghde@');
             t.end();
         });
 
@@ -109,8 +134,13 @@ test('polyline', function(t) {
     });
 
     t.test('#toGeoJSON()', function(t) {
-        t.test('flips coordinates and decodes geometry', function(t) {
-            t.deepEqual(polyline.toGeoJSON('_p~iF~ps|U_ulLnnqC_mqNvxq`@'), geojson.geometry);
+        t.test('flips linestring coordinates and decodes geometry', function(t) {
+            t.deepEqual(polyline.toGeoJSON('_p~iF~ps|U_ulLnnqC_mqNvxq`@'), geojsonLineString.geometry);
+            t.end();
+        });
+
+        t.test('flips point coordinate and decodes geometry', function(t) {
+            t.deepEqual(polyline.toGeoJSON('_p~iF~ps|U'), geojsonPoint);
             t.end();
         });
 


### PR DESCRIPTION
There's no good reason that I can think of why (at least) Point and Polygon geometry types can't be encoded/decoded using the Polyline algorithm.

This PR includes some minor changes (including unit tests) so that these two basic geometry types can be easily supported on this amazing library.

Important: For obvious reasons, when present in GeoJSON geometries, holes in Polygons will be silently ignored.