### PR TITLE
Fix reversing of coordinates when there are more than 2 coordinates in the array

### DIFF
--- a/src/polyline.js
+++ b/src/polyline.js
@@ -118,7 +118,8 @@ polyline.encode = function(coordinates, precision) {
 function flipped(coords) {
     var flipped = [];
     for (var i = 0; i < coords.length; i++) {
-        flipped.push(coords[i].slice().reverse());
+        var coord = coords[i].slice();
+        flipped.push([coord[1], coord[0]]);
     }
     return flipped;
 }

--- a/test/polyline.test.js
+++ b/test/polyline.test.js
@@ -5,6 +5,7 @@ var test = require('tap').test,
 
 test('polyline', function(t) {
     var example = [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
+        exampleWithZ = [[38.5, -120.2, 0], [40.7, -120.95, 0], [43.252, -126.453, 0]],
         example_zero = [[39, -120], [41, -121], [43, -126]],
         // encoded value will enclude slashes -> tests escaping
         example_slashes = [[35.6, -82.55], [35.59985, -82.55015], [35.6, -82.55]],
@@ -66,6 +67,11 @@ test('polyline', function(t) {
 
         t.test('encodes an Array of lat/lon pairs into a String', function(t) {
             t.equal(polyline.encode(example), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.test('encodes an Array of lat/lon/z into the same string as lat/lon', function(t) {
+            t.equal(polyline.encode(exampleWithZ), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
             t.end();
         });
 


### PR DESCRIPTION
Currently the entire array of coords in reversed in order to swap the lat/lon, this happens regards of how long the coordinate array is. In the case of geometry with lat/lon/z, this is problematic because the z value gets shifted to the front resulting in incorrect encoding.

Have added a test to ensure the same result is generated between a set of coords with [x,y] and [x,y,z]

Resolves #64 

cc @andrewharvey